### PR TITLE
feat: add speed range handling and initialize it as hidden

### DIFF
--- a/src/UIBuilder.js
+++ b/src/UIBuilder.js
@@ -1,6 +1,8 @@
 class UIBuilder {
     constructor() {
       this.container = null;
+      this.minSpeedInput = null;
+      this.maxSpeedInput = null;
     }
   
     createShowButton() {
@@ -11,40 +13,51 @@ class UIBuilder {
     }
   
     createFileInput() {
-      const fileInput = document.createElement("input");
-      fileInput.id = "gpx-file-input";
-      fileInput.style.display = "none";
+      const fileInputContainer = document.createElement("div");
+      fileInputContainer.style.display = "none";
+      fileInputContainer.id = "gpx-file-input";
+
+      const label = document.createElement("label");
+      label.innerText = "GPX File Loader";
+      label.style.display = "block";
+      label.style.marginBottom = "8px"; 
+
+      const fileInput = document.createElement("input");      
       fileInput.type = "file";
       fileInput.accept = ".gpx";
-      return fileInput;
+
+      fileInputContainer.appendChild(label);
+      fileInputContainer.appendChild(fileInput);
+      
+      return fileInputContainer;
     }
   
-    createSpeedInputFields() {
+    createSpeedContainer() {
       const speedContainer = document.createElement("div");
-      speedContainer.id = "speed-input-fields";
+      speedContainer.id = "speed-container";
       speedContainer.style.display = "none";
       speedContainer.style.flexDirection = "column";
       speedContainer.style.padding = "8px";
   
       const minSpeedLabel = document.createElement("label");
       minSpeedLabel.innerText = "Min Speed (km/h):";
-      const minSpeedInput = document.createElement("input");
-      minSpeedInput.type = "number";
-      minSpeedInput.value = 0;
-      minSpeedInput.style.marginBottom = "8px";
-      minSpeedInput.style.width = "60px";
+      this.minSpeedInput = document.createElement("input");
+      this.minSpeedInput.id = "min-speed-input"; 
+      this.minSpeedInput.type = "number";
+      this.minSpeedInput.style.marginBottom = "8px";
+      this.minSpeedInput.style.width = "60px";
   
       const maxSpeedLabel = document.createElement("label");
       maxSpeedLabel.innerText = "Max Speed (km/h):";
-      const maxSpeedInput = document.createElement("input");
-      maxSpeedInput.type = "number";
-      maxSpeedInput.value = 20;
-      maxSpeedInput.style.width = "60px";
+      this.maxSpeedInput = document.createElement("input");
+      this.maxSpeedInput.id = "max-speed-input";
+      this.maxSpeedInput.type = "number";
+      this.maxSpeedInput.style.width = "60px";
   
       speedContainer.appendChild(minSpeedLabel);
-      speedContainer.appendChild(minSpeedInput);
+      speedContainer.appendChild(this.minSpeedInput);
       speedContainer.appendChild(maxSpeedLabel);
-      speedContainer.appendChild(maxSpeedInput);
+      speedContainer.appendChild(this.maxSpeedInput);
   
       return speedContainer;
     }
@@ -55,12 +68,16 @@ class UIBuilder {
   
       const showButton = this.createShowButton();
       const fileInput = this.createFileInput();
-      const speedInputFields = this.createSpeedInputFields();
+      const speedContainer = this.createSpeedContainer();
   
       this.container.appendChild(showButton);
       this.container.appendChild(fileInput);
-      this.container.appendChild(speedInputFields);
+      this.container.appendChild(speedContainer);
     }
+    setSpeedContainerVisibility = (isVisible) => {
+      const speedContainer = this.container.querySelector("#speed-container");
+      speedContainer.style.display = isVisible ? "flex" : "none";
+    };
   }
 
   export default UIBuilder;


### PR DESCRIPTION
- Added logic to compute the speed range from the GPX data.
- Initial state of the speed range input fields is set to hidden.
- Speed container visibility is toggled based on the presence of loaded GPX data.

Close: #4 

## Pull Request Type
Mark one with an "x".
```
[x] Adding a Feature
[] Fixing a Bug
[] Documentation Update
[] Style (formatting, naming, or indentation)
[] Refactor (restructure code, no functional changes)
[] Minor Change (does not break existing behavior)
[] Breaking Change (modifies public interface or behavior)
[] Adding/Updating Tests
[] Chore (e.g., file restructuring, build setup)
[] Other (please specify)
```

## Screenshots (optional)


## What to Check (optional)


## What you tested (optional)


## Related issue(s) (optional)


## Other Information (optional)

