### PR TITLE
feat: add speed range handling and initialize it as hidden

### DIFF
--- a/src/UIBuilder.js
+++ b/src/UIBuilder.js
@@ -1,6 +1,8 @@
 class UIBuilder {
     constructor() {
       this.container = null;
+      this.minSpeedInput = null;
+      this.maxSpeedInput = null;
     }
   
     createShowButton() {
@@ -11,40 +13,51 @@ class UIBuilder {
     }
   
     createFileInput() {
-      const fileInput = document.createElement("input");
-      fileInput.id = "gpx-file-input";
-      fileInput.style.display = "none";
+      const fileInputContainer = document.createElement("div");
+      fileInputContainer.style.display = "none";
+      fileInputContainer.id = "gpx-file-input";
+
+      const label = document.createElement("label");
+      label.innerText = "GPX File Loader";
+      label.style.display = "block";
+      label.style.marginBottom = "8px"; 
+
+      const fileInput = document.createElement("input");      
       fileInput.type = "file";
       fileInput.accept = ".gpx";
-      return fileInput;
+
+      fileInputContainer.appendChild(label);
+      fileInputContainer.appendChild(fileInput);
+      
+      return fileInputContainer;
     }
   
-    createSpeedInputFields() {
+    createSpeedContainer() {
       const speedContainer = document.createElement("div");
-      speedContainer.id = "speed-input-fields";
+      speedContainer.id = "speed-container";
       speedContainer.style.display = "none";
       speedContainer.style.flexDirection = "column";
       speedContainer.style.padding = "8px";
   
       const minSpeedLabel = document.createElement("label");
       minSpeedLabel.innerText = "Min Speed (km/h):";
-      const minSpeedInput = document.createElement("input");
-      minSpeedInput.type = "number";
-      minSpeedInput.value = 0;
-      minSpeedInput.style.marginBottom = "8px";
-      minSpeedInput.style.width = "60px";
+      this.minSpeedInput = document.createElement("input");
+      this.minSpeedInput.id = "min-speed-input"; 
+      this.minSpeedInput.type = "number";
+      this.minSpeedInput.style.marginBottom = "8px";
+      this.minSpeedInput.style.width = "60px";
   
       const maxSpeedLabel = document.createElement("label");
       maxSpeedLabel.innerText = "Max Speed (km/h):";
-      const maxSpeedInput = document.createElement("input");
-      maxSpeedInput.type = "number";
-      maxSpeedInput.value = 20;
-      maxSpeedInput.style.width = "60px";
+      this.maxSpeedInput = document.createElement("input");
+      this.maxSpeedInput.id = "max-speed-input";
+      this.maxSpeedInput.type = "number";
+      this.maxSpeedInput.style.width = "60px";
   
       speedContainer.appendChild(minSpeedLabel);
-      speedContainer.appendChild(minSpeedInput);
+      speedContainer.appendChild(this.minSpeedInput);
       speedContainer.appendChild(maxSpeedLabel);
-      speedContainer.appendChild(maxSpeedInput);
+      speedContainer.appendChild(this.maxSpeedInput);
   
       return speedContainer;
     }
@@ -55,12 +68,16 @@ class UIBuilder {
   
       const showButton = this.createShowButton();
       const fileInput = this.createFileInput();
-      const speedInputFields = this.createSpeedInputFields();
+      const speedContainer = this.createSpeedContainer();
   
       this.container.appendChild(showButton);
       this.container.appendChild(fileInput);
-      this.container.appendChild(speedInputFields);
+      this.container.appendChild(speedContainer);
     }
+    setSpeedContainerVisibility = (isVisible) => {
+      const speedContainer = this.container.querySelector("#speed-container");
+      speedContainer.style.display = isVisible ? "flex" : "none";
+    };
   }
 
   export default UIBuilder;

--- a/src/maplibre-gl-gps-track.js
+++ b/src/maplibre-gl-gps-track.js
@@ -9,11 +9,10 @@ class GPSTrackControl {
   constructor() {
     this.container = null;
     this.map = null;
-    this.minSpeedKmPerHour = 0;
-    this.maxSpeedKmPerHour = 20;
     this.minHeartRateBpm = 50;
     this.maxHeartRateBpm = 200;
     this.uiBuilder = new UIBuilder();
+    this.isGPXLoaded = false;
   }
 
   onFileChange = (event) => {
@@ -72,6 +71,13 @@ class GPSTrackControl {
   };
 
   updateLineStyle = () => {
+    const minSpeed = this.minSpeedKmPerHour;
+    const maxSpeed = this.maxSpeedKmPerHour;
+
+    if (maxSpeed < minSpeed) {
+      return;
+    }
+
     if (this.map.getLayer(GPSTrackControl.LAYER_ID)) {
       this.map.setPaintProperty(
         GPSTrackControl.LAYER_ID,
@@ -103,7 +109,39 @@ class GPSTrackControl {
     }
   };
 
-  calculateBounds(features) {
+  getSpeedRange(features) {
+    let minSpeed = Infinity;
+    let maxSpeed = -Infinity;
+
+    features.forEach((feature) => {
+      const speed = feature.properties?.speed;
+
+      if (speed !== undefined) {
+        minSpeed = Math.min(minSpeed, speed);
+        maxSpeed = Math.max(maxSpeed, speed);
+      }
+    });
+
+    return { minSpeed, maxSpeed };
+  }
+
+  updateSpeedRange(features) {
+    const speedRange = this.getSpeedRange(features);
+    this.minSpeedKmPerHour = Math.round(speedRange.minSpeed);
+    this.maxSpeedKmPerHour = Math.round(speedRange.maxSpeed);
+
+    const minSpeedInput = this.container.querySelector("#min-speed-input");
+    const maxSpeedInput = this.container.querySelector("#max-speed-input");
+
+    if (minSpeedInput) {
+      minSpeedInput.value = this.minSpeedKmPerHour;
+    }
+    if (maxSpeedInput) {
+      maxSpeedInput.value = this.maxSpeedKmPerHour;
+    }
+  }
+
+  getBounds(features) {
     let minLat = Infinity,
       maxLat = -Infinity,
       minLng = Infinity,
@@ -123,7 +161,7 @@ class GPSTrackControl {
   }
 
   moveMap = (features) => {
-    const { minLat, maxLat, minLng, maxLng } = this.calculateBounds(features);
+    const { minLat, maxLat, minLng, maxLng } = this.getBounds(features);
 
     this.map.fitBounds(
       [
@@ -137,8 +175,19 @@ class GPSTrackControl {
     );
   };
 
+  updateSpeedInputs = () => {
+    const minSpeedInput = document.getElementById("min-speed-input");
+    const maxSpeedInput = document.getElementById("max-speed-input");
+
+    minSpeedInput.value = this.minSpeedKmPerHour;
+    maxSpeedInput.value = this.maxSpeedKmPerHour;
+  };
+
   renderLine = ({ geojson }) => {
+    this.isGPXLoaded = true;
     this.removeLineIfExists();
+    this.updateSpeedRange(geojson.features);
+    this.uiBuilder.setSpeedContainerVisibility(this.isGPXLoaded);
     this.addLine(geojson, this.createLineStyle());
     this.moveMap(geojson.features);
   };
@@ -152,18 +201,16 @@ class GPSTrackControl {
 
   showHideUI = (isVisible) => {
     const fileInput = this.container.querySelector("#gpx-file-input");
-    const speedInputFields = this.container.querySelector("div");
-    const showButton = this.container.querySelector("button");
+    const showButton = this.container.querySelector("#show-button");
 
     if (isVisible) {
       fileInput.style.display = "block";
-      speedInputFields.style.display = "block";
+      this.uiBuilder.setSpeedContainerVisibility(this.isGPXLoaded);
       showButton.style.display = "none";
-
       document.addEventListener("click", this.closeOnClickOutside);
     } else {
       fileInput.style.display = "none";
-      speedInputFields.style.display = "none";
+      this.uiBuilder.setSpeedContainerVisibility(false);
       showButton.style.display = "block";
     }
   };
@@ -171,9 +218,8 @@ class GPSTrackControl {
   attachEventListeners() {
     const showButton = this.container.querySelector("#show-button");
     const fileInput = this.container.querySelector("#gpx-file-input");
-    const speedInputFields = this.container.querySelector(
-      "#speed-input-fields"
-    );
+    const minSpeedInput = this.container.querySelector("#min-speed-input");
+    const maxSpeedInput = this.container.querySelector("#max-speed-input");
 
     showButton.addEventListener("click", () => {
       this.showHideUI(true);
@@ -181,8 +227,28 @@ class GPSTrackControl {
 
     fileInput.addEventListener("change", this.onFileChange);
 
-    speedInputFields.addEventListener("input", () => {
-      this.updateLineStyle();
+    minSpeedInput.addEventListener("input", (event) => {
+      const inputValue = event.target.value;
+      if (inputValue === "") {
+        return;
+      }
+      const value = parseFloat(inputValue);
+      if (!isNaN(value)) {
+        this.minSpeedKmPerHour = value;
+        this.updateLineStyle();
+      }
+    });
+    
+    maxSpeedInput.addEventListener("input", (event) => {
+      const inputValue = event.target.value;
+      if (inputValue === "") {
+        return;
+      }
+      const value = parseFloat(inputValue);
+      if (!isNaN(value)) {
+        this.maxSpeedKmPerHour = value;
+        this.updateLineStyle();
+      }
     });
   }
 


### PR DESCRIPTION
- Added logic to compute the speed range from the GPX data.
- Initial state of the speed range input fields is set to hidden.
- Speed container visibility is toggled based on the presence of loaded GPX data.

Close: #4 
## Pull Request Type
Mark one with an "x".
```
[x] Adding a Feature
[] Fixing a Bug
[] Documentation Update
[] Style (formatting, naming, or indentation)
[] Refactor (restructure code, no functional changes)
[] Minor Change (does not break existing behavior)
[] Breaking Change (modifies public interface or behavior)
[] Adding/Updating Tests
[] Chore (e.g., file restructuring, build setup)
[] Other (please specify)
```

## Screenshots (optional)


## What to Check (optional)


## What you tested (optional)


## Related issue(s) (optional)


## Other Information (optional)

